### PR TITLE
Fix nested structures generate files even without marker comments

### DIFF
--- a/analyzers/govalid/govalid.go
+++ b/analyzers/govalid/govalid.go
@@ -138,7 +138,8 @@ func analyzeMarker(pass *codegen.Pass, markersInspect markers.Markers, structTyp
 			}
 
 			analyzed = append(analyzed, &AnalyzedMetadata{
-				Validators: validators,
+				Validators:     validators,
+				ParentVariable: parent,
 			})
 
 			continue

--- a/analyzers/govalid/govalid.go
+++ b/analyzers/govalid/govalid.go
@@ -164,10 +164,12 @@ func analyzeMarker(pass *codegen.Pass, markersInspect markers.Markers, structTyp
 			parentVariable = field.Names[0].Name
 		}
 
-		analyzed = append(analyzed, &AnalyzedMetadata{
-			Validators:     validators,
-			ParentVariable: parentVariable,
-		})
+		if len(validators) > 0 {
+			analyzed = append(analyzed, &AnalyzedMetadata{
+				Validators:     validators,
+				ParentVariable: parentVariable,
+			})
+		}
 
 		// Recursively analyze nested structs
 		analyzed = append(analyzed, analyzeMarker(pass, markersInspect, structType, parentVariable, structName)...)


### PR DESCRIPTION
Fixes #91 

Hi all.
Fixed a bug that caused files to be generated for nested structures even though marker comments did not exist.
```go
package main

type A struct {
	B struct {
		X string
	}
}
```

When analyzing a structure, the length of the `validators` variable is checked to avoid unnecessary appends to the analyze.


However, the analysis of the nested structure with markers did not work as it was:
```go
package main

type A struct {
	B struct {
		// +govalid:required
		X string
	}
}
```

generated file:
```go
// Code generated by govalid; DO NOT EDIT.
package main

import (
	"errors"
)

var (
	// ErrNilA is returned when the A is nil.
	ErrNilA = errors.New("input A is nil")

	// ErrAXRequiredValidation is returned when the AX is required but not provided.
	ErrAXRequiredValidation = errors.New("field AX is required")
)

func ValidateA(t *A) error {
	if t == nil {
		return ErrNilA
	}

	if t.X == "" {
		return ErrAXRequiredValidation
	}

	return nil
}
```

```go
if t.X == "" { 
```

This part causes a compile error.
`parent` variable is not passed when analyzing a field in a nested structure.
I also fixed that.
Please let me know if this fix has any side effects 🙇 