### PR TITLE
enable thelper in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,7 @@ linters:
     - revive
     - staticcheck
     - tagliatelle
+    - thelper
     - unconvert
     - unparam
     - unused

--- a/validation/validationhelper/email_test.go
+++ b/validation/validationhelper/email_test.go
@@ -451,6 +451,8 @@ func FuzzIsValidEmail(f *testing.F) {
 }
 
 func addEmailFuzzSeeds(f *testing.F) {
+	f.Helper()
+
 	seeds := []string{
 		"user@example.com",
 		"test.email@domain.org",
@@ -484,6 +486,8 @@ func addEmailFuzzSeeds(f *testing.F) {
 }
 
 func validateEmailStructure(t *testing.T, email string) {
+	t.Helper()
+
 	// Valid emails must have basic structural requirements
 	if len(email) < 5 || len(email) > 254 {
 		t.Errorf("IsValidEmail(%q) returned true but length is invalid: %d", email, len(email))
@@ -507,6 +511,8 @@ func validateEmailStructure(t *testing.T, email string) {
 }
 
 func validateEmailDomainDot(t *testing.T, email string) {
+	t.Helper()
+
 	atIndex := -1
 
 	for i, c := range email {

--- a/validation/validationhelper/url_test.go
+++ b/validation/validationhelper/url_test.go
@@ -271,6 +271,8 @@ func FuzzIsValidURL(f *testing.F) {
 }
 
 func addURLFuzzSeeds(f *testing.F) {
+	f.Helper()
+
 	seeds := []string{
 		"https://example.com",
 		"http://example.com",
@@ -331,6 +333,8 @@ func addURLFuzzSeeds(f *testing.F) {
 }
 
 func validateURLStructure(t *testing.T, url string) {
+	t.Helper()
+
 	// Valid URLs must contain a colon for the scheme separator
 	if !validateURLHasColon(t, url) {
 		return
@@ -341,6 +345,8 @@ func validateURLStructure(t *testing.T, url string) {
 }
 
 func validateURLHasColon(t *testing.T, url string) bool {
+	t.Helper()
+
 	hasColon := false
 
 	for _, c := range url {
@@ -361,6 +367,8 @@ func validateURLHasColon(t *testing.T, url string) bool {
 }
 
 func validateURLScheme(t *testing.T, url string) {
+	t.Helper()
+
 	colonPos := -1
 
 	for i, c := range url {
@@ -391,6 +399,8 @@ func validateURLScheme(t *testing.T, url string) {
 }
 
 func validateURLCharacters(t *testing.T, url string) {
+	t.Helper()
+
 	// URLs should not contain control characters or spaces
 	for i, c := range url {
 		if c < 32 || c == 127 {

--- a/validation/validationhelper/uuid_test.go
+++ b/validation/validationhelper/uuid_test.go
@@ -326,6 +326,8 @@ func FuzzIsValidUUID(f *testing.F) {
 }
 
 func addUUIDFuzzSeeds(f *testing.F) {
+	f.Helper()
+
 	seeds := []string{
 		"550e8400-e29b-41d4-a716-446655440000",
 		"f47ac10b-58cc-4372-a567-0e02b2c3d479",
@@ -358,6 +360,8 @@ func addUUIDFuzzSeeds(f *testing.F) {
 }
 
 func validateUUIDStructure(t *testing.T, uuid string) {
+	t.Helper()
+
 	// Valid UUIDs must be exactly 36 characters
 	if len(uuid) != 36 {
 		t.Errorf("IsValidUUID(%q) returned true but length is %d, expected 36", uuid, len(uuid))
@@ -371,6 +375,8 @@ func validateUUIDStructure(t *testing.T, uuid string) {
 }
 
 func validateUUIDHyphens(t *testing.T, uuid string) {
+	t.Helper()
+
 	// Must have hyphens at positions 8, 13, 18, 23
 	if len(uuid) >= 24 {
 		expectedHyphenPositions := []int{8, 13, 18, 23}
@@ -383,6 +389,8 @@ func validateUUIDHyphens(t *testing.T, uuid string) {
 }
 
 func validateUUIDVersionAndVariant(t *testing.T, uuid string) {
+	t.Helper()
+
 	// Special cases: allow nil UUID and max UUID
 	if uuid == "00000000-0000-0000-0000-000000000000" || uuid == "ffffffff-ffff-ffff-ffff-ffffffffffff" {
 		return
@@ -393,6 +401,8 @@ func validateUUIDVersionAndVariant(t *testing.T, uuid string) {
 }
 
 func validateUUIDVersion(t *testing.T, uuid string) {
+	t.Helper()
+
 	// Version must be 1-5 (position 14)
 	if len(uuid) > 14 {
 		version := uuid[14]
@@ -403,6 +413,8 @@ func validateUUIDVersion(t *testing.T, uuid string) {
 }
 
 func validateUUIDVariant(t *testing.T, uuid string) {
+	t.Helper()
+
 	// Variant must be 8, 9, A, B (position 19)
 	if len(uuid) > 19 {
 		variant := uuid[19]
@@ -424,6 +436,8 @@ func validateUUIDVariant(t *testing.T, uuid string) {
 }
 
 func validateUUIDHexChars(t *testing.T, uuid string) {
+	t.Helper()
+
 	// All non-hyphen characters must be valid hex
 	if len(uuid) != 36 {
 		return


### PR DESCRIPTION
- **enable thelper in golangci-lint**

It enforces the usage of t.Helper() in testing helpers.

By doing so, the test failures are reported at the right place
instead of the helper function.

- **fix errors reported by thelper linter**
