### PR TITLE
Remove reset stop timer from benchmark tests

### DIFF
--- a/test/benchmark/benchmark_alpha_test.go
+++ b/test/benchmark/benchmark_alpha_test.go
@@ -14,33 +14,28 @@ import (
 
 func BenchmarkGoValidAlpha(b *testing.B) {
 	instance := test.Alpha{FirstName: "John", LastName: "Doe", CountryCode: "US"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateAlpha(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundAlpha(b *testing.B) {
 	validate := validator.New()
 	instance := test.Alpha{FirstName: "John", LastName: "Doe", CountryCode: "US"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationAlpha(b *testing.B) {
 	instance := test.Alpha{FirstName: "John", LastName: "Doe", CountryCode: "US"}
 	alphaRegexp := regexp.MustCompile(`^[A-Za-z]+$`)
-	b.ResetTimer()
 	for b.Loop() {
 		err := ozzovalidation.Validate(instance.FirstName, ozzovalidation.Match(alphaRegexp))
 		if err != nil {
@@ -55,28 +50,23 @@ func BenchmarkOzzoValidationAlpha(b *testing.B) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkAsaskevichGovalidatorAlpha(b *testing.B) {
 	instance := test.Alpha{FirstName: "John", LastName: "Doe", CountryCode: "US"}
-	b.ResetTimer()
 	for b.Loop() {
 		if !govalidator.IsAlpha(instance.FirstName) && !govalidator.IsAlpha(instance.LastName) && !govalidator.IsAlpha(instance.CountryCode) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateAlpha(b *testing.B) {
 	instance := test.Alpha{FirstName: "John", LastName: "Doe", CountryCode: "US"}
 	v := validate.Struct(instance)
-	b.ResetTimer()
 	for b.Loop() {
 		if !v.Validate() {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_cel_test.go
+++ b/test/benchmark/benchmark_cel_test.go
@@ -14,14 +14,12 @@ func BenchmarkGoValidCELBasic(b *testing.B) {
 		Score:    85.5,
 		IsActive: true,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateCEL(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 // BenchmarkGoValidCELCrossField tests cross-field validation performance
@@ -32,15 +30,12 @@ func BenchmarkGoValidCELCrossField(b *testing.B) {
 		Quantity: 2.0,
 		Budget:   500.0,
 	}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateCELCrossField(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 // BenchmarkGoValidCELStringLength tests string length validation
@@ -52,14 +47,12 @@ func BenchmarkGoValidCELStringLength(b *testing.B) {
 		IsActive: true,
 	}
 
-	b.ResetTimer()
 	for b.Loop() {
 		// Focus on just the name validation (len(t.Name) > 0)
 		if !(len(instance.Name) > 0) {
 			b.Fatal("name validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 // BenchmarkGoValidCELNumericComparison tests numeric comparison
@@ -71,12 +64,10 @@ func BenchmarkGoValidCELNumericComparison(b *testing.B) {
 		IsActive: true,
 	}
 
-	b.ResetTimer()
 	for b.Loop() {
 		// Focus on just the score validation (t.Score > 0)
 		if !(instance.Score > 0) {
 			b.Fatal("score validation failed")
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_email_test.go
+++ b/test/benchmark/benchmark_email_test.go
@@ -14,55 +14,46 @@ import (
 
 func BenchmarkGoValidEmail(b *testing.B) {
 	instance := test.Email{Email: "user@example.com"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateEmail(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundEmail(b *testing.B) {
 	validate := validator.New()
 	instance := test.Email{Email: "user@example.com"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorEmail(b *testing.B) {
 	testEmail := "user@example.com"
-	b.ResetTimer()
 	for b.Loop() {
 		if !govalidator.IsEmail(testEmail) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationEmail(b *testing.B) {
 	testEmail := "user@example.com"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testEmail, is.Email)
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateEmail(b *testing.B) {
 	testEmail := "user@example.com"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"email": testEmail})
 		v.StringRule("email", "email")
@@ -70,5 +61,4 @@ func BenchmarkGookitValidateEmail(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_enum_test.go
+++ b/test/benchmark/benchmark_enum_test.go
@@ -16,12 +16,10 @@ func BenchmarkGoValidEnum(b *testing.B) {
 		UserRole: "manager",
 		Priority: 10,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateEnum(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_gt_test.go
+++ b/test/benchmark/benchmark_gt_test.go
@@ -14,14 +14,12 @@ func BenchmarkGoValidGT(b *testing.B) {
 	instance := test.GT{
 		Age: 150,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateGT(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundGT(b *testing.B) {
@@ -29,20 +27,17 @@ func BenchmarkGoPlaygroundGT(b *testing.B) {
 	instance := test.GT{
 		Age: 150,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorGT(b *testing.B) {
 	testValue := 150
 	testString := strconv.Itoa(testValue)
-	b.ResetTimer()
 	for b.Loop() {
 		// Check if numeric and > 100
 		if !govalidator.IsNumeric(testString) {
@@ -52,5 +47,4 @@ func BenchmarkGoValidatorGT(b *testing.B) {
 			b.Fatal("validation failed - not greater than 100")
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_gte_test.go
+++ b/test/benchmark/benchmark_gte_test.go
@@ -10,27 +10,21 @@ import (
 
 func BenchmarkGoValidGTE(b *testing.B) {
 	instance := test.GTE{Age: 25}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateGTE(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundGTE(b *testing.B) {
 	validate := validator.New()
 	instance := test.GTE{Age: 25}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_length_test.go
+++ b/test/benchmark/benchmark_length_test.go
@@ -15,14 +15,12 @@ func BenchmarkGoValidLength(b *testing.B) {
 	instance := test.Length{
 		Name: "1234567",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateLength(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundLength(b *testing.B) {
@@ -30,42 +28,35 @@ func BenchmarkGoPlaygroundLength(b *testing.B) {
 	instance := test.Length{
 		Name: "1234567",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorLength(b *testing.B) {
 	testString := "1234567"
-	b.ResetTimer()
 	for b.Loop() {
 		if !govalidator.StringLength(testString, "7", "7") {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationLength(b *testing.B) {
 	testString := "1234567"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testString, validation.Length(7, 7))
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateLength(b *testing.B) {
 	testString := "1234567"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"name": testString})
 		v.StringRule("name", "rune_len:7")
@@ -73,5 +64,4 @@ func BenchmarkGookitValidateLength(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_lt_test.go
+++ b/test/benchmark/benchmark_lt_test.go
@@ -12,14 +12,12 @@ func BenchmarkGoValidLT(b *testing.B) {
 	instance := test.LT{
 		Age: 5,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateLT(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundLT(b *testing.B) {
@@ -27,12 +25,10 @@ func BenchmarkGoPlaygroundLT(b *testing.B) {
 	instance := test.LT{
 		Age: 5,
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_lte_test.go
+++ b/test/benchmark/benchmark_lte_test.go
@@ -10,27 +10,21 @@ import (
 
 func BenchmarkGoValidLTE(b *testing.B) {
 	instance := test.LTE{Age: 75}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateLTE(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundLTE(b *testing.B) {
 	validate := validator.New()
 	instance := test.LTE{Age: 75}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_maxitems_test.go
+++ b/test/benchmark/benchmark_maxitems_test.go
@@ -12,14 +12,12 @@ func BenchmarkGoValidMaxItems(b *testing.B) {
 	instance := test.MaxItems{
 		Items: []string{"item1", "item2", "item3"},
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateMaxItems(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundMaxItems(b *testing.B) {
@@ -27,12 +25,10 @@ func BenchmarkGoPlaygroundMaxItems(b *testing.B) {
 	instance := test.MaxItems{
 		Items: []string{"item1", "item2", "item3"},
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_maxlength_test.go
+++ b/test/benchmark/benchmark_maxlength_test.go
@@ -15,14 +15,12 @@ func BenchmarkGoValidMaxLength(b *testing.B) {
 	instance := test.MaxLength{
 		Name: "This is a test string for maxlength validation",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateMaxLength(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundMaxLength(b *testing.B) {
@@ -30,43 +28,36 @@ func BenchmarkGoPlaygroundMaxLength(b *testing.B) {
 	instance := test.MaxLength{
 		Name: "This is a test string for maxlength validation",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorMaxLength(b *testing.B) {
 	testString := "This is a test string for maxlength validation"
-	b.ResetTimer()
 	for b.Loop() {
 		// Use StringLength function with max length 50
 		if !govalidator.StringLength(testString, "0", "50") {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationMaxLength(b *testing.B) {
 	testString := "This is a test string for maxlength validation"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testString, validation.Length(0, 50))
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateMaxLength(b *testing.B) {
 	testString := "This is a test string for maxlength validation"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"test": testString})
 		v.StringRule("test", "max_len:50")
@@ -74,5 +65,4 @@ func BenchmarkGookitValidateMaxLength(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_minitems_test.go
+++ b/test/benchmark/benchmark_minitems_test.go
@@ -16,15 +16,12 @@ func BenchmarkGoValidMinItems(b *testing.B) {
 	}
 	instance.ChanField <- 1
 	instance.ChanField <- 2
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateMinItems(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundMinItems(b *testing.B) {
@@ -36,13 +33,10 @@ func BenchmarkGoPlaygroundMinItems(b *testing.B) {
 	}
 	instance.ChanField <- 1
 	instance.ChanField <- 2
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_minlength_test.go
+++ b/test/benchmark/benchmark_minlength_test.go
@@ -11,39 +11,31 @@ import (
 
 func BenchmarkGoValidMinLength(b *testing.B) {
 	instance := test.MinLength{Name: "test string with adequate length"}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateMinLength(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundMinLength(b *testing.B) {
 	validate := validator.New()
 	instance := test.MinLength{Name: "test string with adequate length"}
-
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorMinLength(b *testing.B) {
 	testString := "test string with adequate length"
-	b.ResetTimer()
 	for b.Loop() {
 		// Use StringLength function with min length 3, max length 50
 		if !govalidator.StringLength(testString, "3", "50") {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_required_test.go
+++ b/test/benchmark/benchmark_required_test.go
@@ -17,14 +17,12 @@ func BenchmarkGoValidRequired(b *testing.B) {
 		Age:   1,
 		Items: []string{"test"},
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateRequired(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundRequired(b *testing.B) {
@@ -34,19 +32,16 @@ func BenchmarkGoPlaygroundRequired(b *testing.B) {
 		Age:   1,
 		Items: []string{"test"},
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorRequired(b *testing.B) {
 	testString := "test"
-	b.ResetTimer()
 	for b.Loop() {
 		// Check if string is not empty
 		if len(testString) == 0 {
@@ -57,24 +52,20 @@ func BenchmarkGoValidatorRequired(b *testing.B) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationRequired(b *testing.B) {
 	testString := "test"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testString, validation.Required)
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateRequired(b *testing.B) {
 	testString := "test"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"test": testString})
 		v.StringRule("test", "required")
@@ -82,5 +73,4 @@ func BenchmarkGookitValidateRequired(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_url_test.go
+++ b/test/benchmark/benchmark_url_test.go
@@ -16,14 +16,12 @@ func BenchmarkGoValidURL(b *testing.B) {
 	instance := test.URL{
 		URL: "https://example.com/path/to/resource?key=value",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateURL(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundURL(b *testing.B) {
@@ -31,42 +29,35 @@ func BenchmarkGoPlaygroundURL(b *testing.B) {
 	instance := test.URL{
 		URL: "https://example.com/path/to/resource?key=value",
 	}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorURL(b *testing.B) {
 	testURL := "https://example.com/path/to/resource?key=value"
-	b.ResetTimer()
 	for b.Loop() {
 		if !govalidator.IsURL(testURL) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationURL(b *testing.B) {
 	testURL := "https://example.com/path/to/resource?key=value"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testURL, is.URL)
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateURL(b *testing.B) {
 	testURL := "https://example.com/path/to/resource?key=value"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"url": testURL})
 		v.StringRule("url", "url")
@@ -74,5 +65,4 @@ func BenchmarkGookitValidateURL(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/benchmark/benchmark_uuid_test.go
+++ b/test/benchmark/benchmark_uuid_test.go
@@ -14,55 +14,46 @@ import (
 
 func BenchmarkGoValidUUID(b *testing.B) {
 	instance := test.UUID{UUID: "6ba7b811-9dad-41d1-80b4-00c04fd430c8"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := test.ValidateUUID(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoPlaygroundUUID(b *testing.B) {
 	validate := validator.New()
 	instance := test.UUID{UUID: "6ba7b811-9dad-41d1-80b4-00c04fd430c8"}
-	b.ResetTimer()
 	for b.Loop() {
 		err := validate.Struct(&instance)
 		if err != nil {
 			b.Fatal("unexpected error:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGoValidatorUUID(b *testing.B) {
 	testUUID := "6ba7b811-9dad-41d1-80b4-00c04fd430c8"
-	b.ResetTimer()
 	for b.Loop() {
 		if !govalidator.IsUUID(testUUID) {
 			b.Fatal("validation failed")
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkOzzoValidationUUID(b *testing.B) {
 	testUUID := "6ba7b811-9dad-41d1-80b4-00c04fd430c8"
-	b.ResetTimer()
 	for b.Loop() {
 		err := validation.Validate(testUUID, is.UUID)
 		if err != nil {
 			b.Fatal("validation failed:", err)
 		}
 	}
-	b.StopTimer()
 }
 
 func BenchmarkGookitValidateUUID(b *testing.B) {
 	testUUID := "6ba7b811-9dad-41d1-80b4-00c04fd430c8"
-	b.ResetTimer()
 	for b.Loop() {
 		v := validate.New(map[string]any{"uuid": testUUID})
 		v.StringRule("uuid", "uuid")
@@ -70,5 +61,4 @@ func BenchmarkGookitValidateUUID(b *testing.B) {
 			b.Fatal("validation failed:", v.Errors)
 		}
 	}
-	b.StopTimer()
 }

--- a/test/marker.go
+++ b/test/marker.go
@@ -143,5 +143,5 @@ type CELCrossField struct {
 
 type Length struct {
 	// +govalid:length=7
-	Name string `json:"name"`
+	Name string `validate:"len=7" json:"name"`
 }


### PR DESCRIPTION
## Description

This pull request removes redundant `b.ResetTimer()` and `b.StopTimer()` calls from all benchmark tests under `test\benchmark`. These changes simplify the benchmark code by relying on the default behavior of `b.Loop()`, which automatically handles timing.

Also, this pull request updates the `Length` struct in `test/marker.go` with the `validate:"len=7"` tag for consistency with go playground length validation.

<!-- Brief description of what this PR accomplishes -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Quality Checklist

Before submitting this pull request, ensure your contribution meets these quality standards:

### Code Quality
- [x] Code passes `make golangci-lint` without errors
- [x] All tests pass: `make test`
- [x] Code follows existing patterns and conventions
- [x] No hard-coded values (use constants or configuration)
- [x] Error messages are clear and actionable

### Testing Requirements
- [ ] Golden tests created and passing (`internal/analyzers/govalid/testdata/`)
- [ ] Unit tests implemented with boundary value testing (`test/unit/`)
- [x] Benchmark tests comparing against popular validation libraries (`test/benchmark/`)
  - [ ] [go-playground/validator](https://github.com/go-playground/validator) (BenchmarkGoPlayground*)
  - [ ] [asaskevich/govalidator](https://github.com/asaskevich/govalidator) (BenchmarkGoValidator*)
  - [ ] [go-ozzo/ozzo-validation](https://github.com/go-ozzo/ozzo-validation) (BenchmarkOzzoValidation*)
  - [ ] [gookit/validate](https://github.com/gookit/validate) (BenchmarkGookitValidate*)
- [x] All test files generated: `cd test && go generate`

### Performance Standards
- [ ] Zero allocations in validation logic (verified via benchmarks)
- [ ] Performance improvement over existing validation libraries (minimum 2x faster)
- [ ] Benchmark results added to `test/benchmark/README.md`

### Documentation
- [ ] README.md updated with new marker documentation
- [ ] Code includes appropriate comments and examples
- [ ] Validator usage examples provided

### Integration
- [ ] Validator scaffold generated with `make generate-validator MARKER=yourmarker`
- [ ] Registry files automatically updated
- [ ] Binary rebuilt and installed: `go install ./cmd/govalid/`

### Final Verification
- [x] All GitHub Actions CI checks pass
- [x] No breaking changes to existing functionality
- [x] Contribution follows project license requirements

## Additional Notes

<!-- Any additional information about the implementation, design decisions, or areas that need special attention -->

## Related Issues

Closes #70 

<!-- Link to any related issues: Fixes #123, Closes #456 -->