### PR TITLE
Adding benchmark syncing to GHA

### DIFF
--- a/.github/workflows/benchmark-sync.yaml
+++ b/.github/workflows/benchmark-sync.yaml
@@ -20,16 +20,13 @@ jobs:
       - name: Check if benchmarks are synced
         id: check-sync
         run: |
-          ./check-benchmark-sync.sh | grep -q "days old"; then
-            if [ $? -eq 0 ]; then
+          if ./check-benchmark-sync.sh | grep -q "days old"; then
               echo "Benchmarks are out of sync, proceeding with sync."
               echo "sync_needed=true" >> $GITHUB_OUTPUT
             else
               echo "Benchmarks are already up to date."
               echo "sync_needed=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmark sync script
         id: sync-benchmarks
@@ -57,5 +54,3 @@ jobs:
           else
             echo "Benchmark sync did not make any changes."
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-sync.yaml
+++ b/.github/workflows/benchmark-sync.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   sync-benchmarks:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ./scripts

--- a/.github/workflows/benchmark-sync.yaml
+++ b/.github/workflows/benchmark-sync.yaml
@@ -6,7 +6,6 @@ on:
 jobs:
   sync-benchmarks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     defaults:
       run:
         working-directory: ./scripts

--- a/.github/workflows/benchmark-sync.yaml
+++ b/.github/workflows/benchmark-sync.yaml
@@ -1,0 +1,61 @@
+name: Sync Benchmarks on push to main
+on:
+  push:
+    branches:
+      - main
+jobs:
+  sync-benchmarks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./scripts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      
+      - name: Check if benchmarks are synced
+        id: check-sync
+        run: |
+          ./check-benchmark-sync.sh | grep -q "days old"; then
+            if [ $? -eq 0 ]; then
+              echo "Benchmarks are out of sync, proceeding with sync."
+              echo "sync_needed=true" >> $GITHUB_OUTPUT
+            else
+              echo "Benchmarks are already up to date."
+              echo "sync_needed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run benchmark sync script
+        id: sync-benchmarks
+        if: steps.check-sync.outputs.sync_needed == 'true'
+        run: ./sync-benchmarks.sh
+      - name: Commit and push changes
+        id: commit-changes
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "github-actions@example.com"
+          git add -A
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to commit"
+            echo "committed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          git commit -m "Sync benchmark results"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify completion
+        run: |
+          if [ "${{ steps.commit-changes.outputs.committed }}" = "true" ]; then
+            echo "Benchmark sync completed successfully."
+          else
+            echo "Benchmark sync did not make any changes."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sync-benchmarks.sh
+++ b/scripts/sync-benchmarks.sh
@@ -11,7 +11,7 @@ echo "🔄 Synchronizing benchmark results across documentation..."
 echo "📊 Running fresh benchmarks..."
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT/test"
-BENCHMARK_OUTPUT=$(go test ./benchmark/ -bench=. -benchmem -benchtime=1s -timeout=20m | grep "^Benchmark" || echo "# Benchmark execution failed")
+BENCHMARK_OUTPUT=$(go test ./benchmark/ -bench=. -benchmem -benchtime=1s -timeout=60m | grep "^Benchmark" || echo "# Benchmark execution failed")
 
 # Get current date and system info
 BENCH_DATE=$(date +"%Y-%m-%d")

--- a/scripts/sync-benchmarks.sh
+++ b/scripts/sync-benchmarks.sh
@@ -11,7 +11,7 @@ echo "🔄 Synchronizing benchmark results across documentation..."
 echo "📊 Running fresh benchmarks..."
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT/test"
-BENCHMARK_OUTPUT=$(go test ./benchmark/ -bench=. -benchmem -benchtime=1s | grep "^Benchmark" || echo "# Benchmark execution failed")
+BENCHMARK_OUTPUT=$(go test ./benchmark/ -bench=. -benchmem -benchtime=1s -timeout=20m | grep "^Benchmark" || echo "# Benchmark execution failed")
 
 # Get current date and system info
 BENCH_DATE=$(date +"%Y-%m-%d")


### PR DESCRIPTION
## Description

This PR aims to move syncing benchmarks to when a PR is pushed to main. This will standardize benchmarks and would disallow contributors from adding benchmarks that were local to their machine to the global `test/benchmark/README.md`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Quality Checklist

### Final Verification
- [ ] All GitHub Actions CI checks pass
- [x] No breaking changes to existing functionality
- [x] Contribution follows project license requirements

## Related Issues

Fix #51 and #117 