### PR TITLE
feat: add deprecation warning for old marker format

### DIFF
--- a/internal/analyzers/markers/analyzer.go
+++ b/internal/analyzers/markers/analyzer.go
@@ -185,7 +185,7 @@ func parseMarkerComment(text, filename string, line int) (string, bool) {
 	}
 	// Old format: // +govalid:xxx (deprecated, kept for backward compatibility)
 	if strings.HasPrefix(text, "// +govalid:") {
-		fmt.Fprintf(os.Stderr, "\033[33mWARNING\033[0m: %s:%d: deprecated marker format \"// +govalid:\"; use \"//govalid:\" instead (run 'govalid migrate' to fix)\n", filename, line)
+		fmt.Fprintf(os.Stderr, "\033[33mWARNING\033[0m: %s:%d: "+`deprecated marker format "// +govalid:"; use "//govalid:" instead (run 'govalid migrate' to fix)`+"\n", filename, line)
 
 		return strings.TrimPrefix(text, "// +"), true
 	}


### PR DESCRIPTION
## Summary

- Print warning to stderr when detecting old format `// +govalid:` to encourage migration to new format `//govalid:`
- Warning includes file path, line number, and suggests running `govalid migrate` to fix

## Example output

```
WARNING: /path/to/file.go:10: deprecated marker format "// +govalid:"; use "//govalid:" instead (run 'govalid migrate' to fix)
```

## Test plan

- [x] Run existing tests to verify backward compatibility still works
- [x] Verify warning is printed for old format markers
- [x] Run linter