### PR TITLE
ci: consolidate coverage reporting to Codecov

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,9 +1,7 @@
 name: Coverage
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
 
 jobs:
   coverage:
@@ -26,5 +24,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./test/coverage.out
+          files: root-coverage.out,test/test-coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -32,63 +31,3 @@ jobs:
           go mod download
       - name: Run tests
         run: make test
-      - name: Check coverage
-        id: coverage
-        run: |
-          cd test && go test -coverprofile=coverage.out -coverpkg=github.com/sivchari/govalid/... ./unit/...
-          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}')
-          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Total Coverage: $COVERAGE**" >> $GITHUB_STEP_SUMMARY
-      - name: Comment coverage on PR
-        if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const coverage = '${{ steps.coverage.outputs.coverage }}';
-
-            let comment = `## 📊 Coverage Report\n\n`;
-            comment += `**Total Coverage: ${coverage}**\n\n`;
-            comment += `<details>\n<summary>Details</summary>\n\n`;
-            comment += `Run \`make coverage\` locally to see detailed coverage by function.\n\n`;
-            comment += `</details>`;
-
-            // Find and delete previous Coverage Report comments
-            try {
-              const comments = await github.rest.issues.listComments({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-
-              const coverageComments = comments.data.filter(c =>
-                c.body.includes('📊 Coverage Report') &&
-                c.user.type === 'Bot'
-              );
-
-              for (const oldComment of coverageComments) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: oldComment.id
-                });
-                console.log(`Deleted previous coverage comment: ${oldComment.id}`);
-              }
-            } catch (error) {
-              console.warn('Failed to delete previous comments:', error.message);
-            }
-
-            // Post new comment to PR
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: comment
-              });
-              console.log('Successfully posted coverage comment');
-            } catch (error) {
-              console.error('Failed to post coverage comment:', error.message);
-              throw error;
-            }

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ docs/public/
 docs/resources/
 
 # Code coverage HTML report
-test/coverage.html
+root-coverage.html
+test/test-coverage.html
 
 /govalid

--- a/Makefile
+++ b/Makefile
@@ -65,16 +65,17 @@ test: ## Run all tests
 
 .PHONY: test-coverage
 test-coverage: ## Run tests with coverage report
-	@echo "Running tests with coverage..."
-	cd test && go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=github.com/sivchari/govalid/... ./unit/...
+	@echo "Running root module tests with coverage..."
+	go test -race -coverprofile=root-coverage.out -covermode=atomic ./...
 	@echo ""
-	@echo "Coverage summary:"
-	@cd test && go tool cover -func=coverage.out | tail -1
+	@echo "Running test module tests with coverage..."
+	cd test && go test -race -coverprofile=test-coverage.out -covermode=atomic -coverpkg=github.com/sivchari/govalid/... ./unit/...
 
 .PHONY: coverage-html
 coverage-html: test-coverage ## Generate HTML coverage report
-	cd test && go tool cover -html=coverage.out -o coverage.html
-	@echo "Coverage report generated: test/coverage.html"
+	go tool cover -html=root-coverage.out -o root-coverage.html
+	cd test && go tool cover -html=test-coverage.out -o test-coverage.html
+	@echo "Coverage reports generated: root-coverage.html, test/test-coverage.html"
 
 # Fuzz test targets
 .PHONY: fuzz

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 3%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "cmd/**"
+  - "internal/**"
+  - "validation/**"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Description

Consolidate coverage reporting to Codecov and remove self-hosted reporting.

- [x] Refactoring (no functional changes)

## Quality Checklist

### Code Quality
- [x] Code follows existing patterns and conventions

### Final Verification
- [x] All GitHub Actions CI checks pass
- [x] No breaking changes to existing functionality

## Additional Notes

### coverage.yaml
- Switch trigger from `push: main` to `pull_request`
- Collect coverage from both root module and test module
- Upload both profiles to Codecov for accurate merged reporting

### codecov.yml (new)
- Project target: 60% (threshold 3%)
- Patch target: 80%
- Ignore `cmd/**`, `internal/**`, `validation/**` (to be removed incrementally in follow-up PRs)

### unit-test.yaml
- Remove self-hosted coverage check step and GitHub Script PR comment
- Remove `pull-requests: write` permission (no longer needed)

### Makefile
- Update `test-coverage` to run both root and test module tests

## Related Issues

Closes #132