### PR TITLE
refactor: remove deprecated legacy error variable aliases

### DIFF
--- a/cmd/generate-validators/templates/validator.go.tmpl
+++ b/cmd/generate-validators/templates/validator.go.tmpl
@@ -50,32 +50,17 @@ func (v *{{.MarkerName}}Validator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-  const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-  `
-
 	const errTemplate = `
 	  // [@ERRVARIABLE] is returned when the [@FIELD] fails {{.MarkerName}} validation.
 	  [@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"{{if .ErrorMessage}}{{.ErrorMessage}}{{else}}field [@FIELD] failed {{.MarkerName}} validation{{end}}",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-  legacyErrVarName := fmt.Sprintf("Err%s%s{{.StructName}}Validation", v.structName, v.FieldName())
-	currentErrVarName := v.ErrVariable()
-
 	replacer := strings.NewReplacer(
-        "[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", v.ErrVariable(),
 		"[@FIELD]", v.FieldName(),
 		"[@PATH]", v.FieldPath().String(),
 		"[@TYPE]", v.ruleName,
 	)
-
-  if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/analyzers/govalid/tests/testdata/gt_test_TestGt_gt.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/gt_test_TestGt_gt.golden.go
@@ -60,11 +60,6 @@ var (
 	// ErrGTComplex128GTValidation is the error returned when the value of the field is less than the 1.
 	ErrGTComplex128GTValidation = govaliderrors.ValidationError{Reason: "field Complex128 must be greater than 1", Path: "GT.Complex128", Type: "gt"}
 
-	// Deprecated: Use ErrGTStructIntGTValidation
-	//
-	// ErrGTIntGTValidation is deprecated and is kept for compatibility purpose.
-	ErrGTIntGTValidation = ErrGTStructIntGTValidation
-
 	// ErrGTStructIntGTValidation is the error returned when the value of the field is less than the 1.
 	ErrGTStructIntGTValidation = govaliderrors.ValidationError{Reason: "field Int must be greater than 1", Path: "GT.Struct.Int", Type: "gt"}
 )

--- a/internal/analyzers/govalid/tests/testdata/gte_test_TestGte_gte.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/gte_test_TestGte_gte.golden.go
@@ -21,11 +21,6 @@ var (
 	// ErrGTEScoreGTEValidation is the error returned when the value of the field is less than 0.
 	ErrGTEScoreGTEValidation = govaliderrors.ValidationError{Reason: "field Score must be greater than or equal to 0", Path: "GTE.Score", Type: "gte"}
 
-	// Deprecated: Use ErrGTEStructValueGTEValidation
-	//
-	// ErrGTEValueGTEValidation is deprecated and is kept for compatibility purpose.
-	ErrGTEValueGTEValidation = ErrGTEStructValueGTEValidation
-
 	// ErrGTEStructValueGTEValidation is the error returned when the value of the field is less than 100.
 	ErrGTEStructValueGTEValidation = govaliderrors.ValidationError{Reason: "field Value must be greater than or equal to 100", Path: "GTE.Struct.Value", Type: "gte"}
 )

--- a/internal/analyzers/govalid/tests/testdata/length_test_TestLength_length.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/length_test_TestLength_length.golden.go
@@ -20,11 +20,6 @@ var (
 	// ErrLengthStringLengthValidation is the error returned when the length of the field is not exactly 7.
 	ErrLengthStringLengthValidation = govaliderrors.ValidationError{Reason: "field String length must be exactly 7", Path: "Length.String", Type: "length"}
 
-	// Deprecated: Use ErrLengthStructNameLengthValidation
-	//
-	// ErrLengthNameLengthValidation is deprecated and is kept for compatibility purpose.
-	ErrLengthNameLengthValidation = ErrLengthStructNameLengthValidation
-
 	// ErrLengthStructNameLengthValidation is the error returned when the length of the field is not exactly 10.
 	ErrLengthStructNameLengthValidation = govaliderrors.ValidationError{Reason: "field Name length must be exactly 10", Path: "Length.Struct.Name", Type: "length"}
 )

--- a/internal/analyzers/govalid/tests/testdata/lt_test_TestLt_lt.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/lt_test_TestLt_lt.golden.go
@@ -60,11 +60,6 @@ var (
 	// ErrLTComplex128LTValidation is the error returned when the value of the field is greater than the 1.
 	ErrLTComplex128LTValidation = govaliderrors.ValidationError{Reason: "field Complex128 must be less than 1", Path: "LT.Complex128", Type: "lt"}
 
-	// Deprecated: Use ErrLTStructIntLTValidation
-	//
-	// ErrLTIntLTValidation is deprecated and is kept for compatibility purpose.
-	ErrLTIntLTValidation = ErrLTStructIntLTValidation
-
 	// ErrLTStructIntLTValidation is the error returned when the value of the field is greater than the 1.
 	ErrLTStructIntLTValidation = govaliderrors.ValidationError{Reason: "field Int must be less than 1", Path: "LT.Struct.Int", Type: "lt"}
 )

--- a/internal/analyzers/govalid/tests/testdata/lte_test_TestLte_lte.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/lte_test_TestLte_lte.golden.go
@@ -21,11 +21,6 @@ var (
 	// ErrLTEScoreLTEValidation is the error returned when the value of the field is greater than 10.5.
 	ErrLTEScoreLTEValidation = govaliderrors.ValidationError{Reason: "field Score must be less than or equal to 10.5", Path: "LTE.Score", Type: "lte"}
 
-	// Deprecated: Use ErrLTEStructValueLTEValidation
-	//
-	// ErrLTEValueLTEValidation is deprecated and is kept for compatibility purpose.
-	ErrLTEValueLTEValidation = ErrLTEStructValueLTEValidation
-
 	// ErrLTEStructValueLTEValidation is the error returned when the value of the field is greater than 50.
 	ErrLTEStructValueLTEValidation = govaliderrors.ValidationError{Reason: "field Value must be less than or equal to 50", Path: "LTE.Struct.Value", Type: "lte"}
 )

--- a/internal/analyzers/govalid/tests/testdata/maxitems_test_TestMaxitems_maxitems.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/maxitems_test_TestMaxitems_maxitems.golden.go
@@ -27,11 +27,6 @@ var (
 	// ErrMaxItemsChanFieldMaxItemsValidation is the error returned when the length of the field exceeds the maximum of 2.
 	ErrMaxItemsChanFieldMaxItemsValidation = govaliderrors.ValidationError{Reason: "field ChanField must have a maximum of 2 items", Path: "MaxItems.ChanField", Type: "maxitems"}
 
-	// Deprecated: Use ErrMaxItemsStructItemsMaxItemsValidation
-	//
-	// ErrMaxItemsItemsMaxItemsValidation is deprecated and is kept for compatibility purpose.
-	ErrMaxItemsItemsMaxItemsValidation = ErrMaxItemsStructItemsMaxItemsValidation
-
 	// ErrMaxItemsStructItemsMaxItemsValidation is the error returned when the length of the field exceeds the maximum of 2.
 	ErrMaxItemsStructItemsMaxItemsValidation = govaliderrors.ValidationError{Reason: "field Items must have a maximum of 2 items", Path: "MaxItems.Struct.Items", Type: "maxitems"}
 )

--- a/internal/analyzers/govalid/tests/testdata/maxlength_test_TestMaxlength_maxlength.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/maxlength_test_TestMaxlength_maxlength.golden.go
@@ -20,11 +20,6 @@ var (
 	// ErrMaxLengthStringMaxLengthValidation is the error returned when the length of the field exceeds the maximum of 10.
 	ErrMaxLengthStringMaxLengthValidation = govaliderrors.ValidationError{Reason: "field String must have a maximum length of 10", Path: "MaxLength.String", Type: "maxlength"}
 
-	// Deprecated: Use ErrMaxLengthStructNameMaxLengthValidation
-	//
-	// ErrMaxLengthNameMaxLengthValidation is deprecated and is kept for compatibility purpose.
-	ErrMaxLengthNameMaxLengthValidation = ErrMaxLengthStructNameMaxLengthValidation
-
 	// ErrMaxLengthStructNameMaxLengthValidation is the error returned when the length of the field exceeds the maximum of 20.
 	ErrMaxLengthStructNameMaxLengthValidation = govaliderrors.ValidationError{Reason: "field Name must have a maximum length of 20", Path: "MaxLength.Struct.Name", Type: "maxlength"}
 )

--- a/internal/analyzers/govalid/tests/testdata/minitems_test_TestMinitems_minitems.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/minitems_test_TestMinitems_minitems.golden.go
@@ -27,11 +27,6 @@ var (
 	// ErrMinItemsChanFieldMinItemsValidation is the error returned when the length of the field is less than the minimum of 2.
 	ErrMinItemsChanFieldMinItemsValidation = govaliderrors.ValidationError{Reason: "field ChanField must have a minimum of 2 items", Path: "MinItems.ChanField", Type: "minitems"}
 
-	// Deprecated: Use ErrMinItemsStructItemsMinItemsValidation
-	//
-	// ErrMinItemsItemsMinItemsValidation is deprecated and is kept for compatibility purpose.
-	ErrMinItemsItemsMinItemsValidation = ErrMinItemsStructItemsMinItemsValidation
-
 	// ErrMinItemsStructItemsMinItemsValidation is the error returned when the length of the field is less than the minimum of 1.
 	ErrMinItemsStructItemsMinItemsValidation = govaliderrors.ValidationError{Reason: "field Items must have a minimum of 1 items", Path: "MinItems.Struct.Items", Type: "minitems"}
 )

--- a/internal/analyzers/govalid/tests/testdata/minlength_test_TestMinlength_minlength.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/minlength_test_TestMinlength_minlength.golden.go
@@ -20,11 +20,6 @@ var (
 	// ErrMinLengthStringMinLengthValidation is the error returned when the length of the field is less than the minimum of 5.
 	ErrMinLengthStringMinLengthValidation = govaliderrors.ValidationError{Reason: "field String must have a minimum length of 5", Path: "MinLength.String", Type: "minlength"}
 
-	// Deprecated: Use ErrMinLengthStructNameMinLengthValidation
-	//
-	// ErrMinLengthNameMinLengthValidation is deprecated and is kept for compatibility purpose.
-	ErrMinLengthNameMinLengthValidation = ErrMinLengthStructNameMinLengthValidation
-
 	// ErrMinLengthStructNameMinLengthValidation is the error returned when the length of the field is less than the minimum of 3.
 	ErrMinLengthStructNameMinLengthValidation = govaliderrors.ValidationError{Reason: "field Name must have a minimum length of 3", Path: "MinLength.Struct.Name", Type: "minlength"}
 )

--- a/internal/analyzers/govalid/tests/testdata/nestedstruct_test_func1_inside.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/nestedstruct_test_func1_inside.golden.go
@@ -15,11 +15,6 @@ var (
 	// ErrNilInside is returned when the Inside is nil.
 	ErrNilInside = errors.New("input Inside is nil")
 
-	// Deprecated: Use ErrInsideAXRequiredValidation
-	//
-	// ErrInsideXRequiredValidation is deprecated and is kept for compatibility purpose.
-	ErrInsideXRequiredValidation = ErrInsideAXRequiredValidation
-
 	// ErrInsideAXRequiredValidation is returned when the X is required but not provided.
 	ErrInsideAXRequiredValidation = govaliderrors.ValidationError{Reason: "field X is required", Path: "Inside.A.X", Type: "required"}
 )

--- a/internal/analyzers/govalid/tests/testdata/required_test_TestRequired_required.golden.go
+++ b/internal/analyzers/govalid/tests/testdata/required_test_TestRequired_required.golden.go
@@ -42,26 +42,11 @@ var (
 	// ErrRequiredEntireRequiredStructNameRequiredValidation is returned when the EntireRequiredStructName is required but not provided.
 	ErrRequiredEntireRequiredStructNameRequiredValidation = govaliderrors.ValidationError{Reason: "field EntireRequiredStructName is required", Path: "Required.EntireRequiredStructName", Type: "required"}
 
-	// Deprecated: Use ErrRequiredPartialStructPartialStructStringRequiredValidation
-	//
-	// ErrRequiredPartialStructStringRequiredValidation is deprecated and is kept for compatibility purpose.
-	ErrRequiredPartialStructStringRequiredValidation = ErrRequiredPartialStructPartialStructStringRequiredValidation
-
 	// ErrRequiredPartialStructPartialStructStringRequiredValidation is returned when the PartialStructString is required but not provided.
 	ErrRequiredPartialStructPartialStructStringRequiredValidation = govaliderrors.ValidationError{Reason: "field PartialStructString is required", Path: "Required.PartialStruct.PartialStructString", Type: "required"}
 
-	// Deprecated: Use ErrRequiredNestedStructNested2StringRequiredValidation
-	//
-	// ErrRequiredNested2StringRequiredValidation is deprecated and is kept for compatibility purpose.
-	ErrRequiredNested2StringRequiredValidation = ErrRequiredNestedStructNested2StringRequiredValidation
-
 	// ErrRequiredNestedStructNested2StringRequiredValidation is returned when the Nested2String is required but not provided.
 	ErrRequiredNestedStructNested2StringRequiredValidation = govaliderrors.ValidationError{Reason: "field Nested2String is required", Path: "Required.NestedStruct.Nested2String", Type: "required"}
-
-	// Deprecated: Use ErrRequiredOtherNestedStructNested2StringRequiredValidation
-	//
-	// ErrRequiredNested2StringRequiredValidation is deprecated and is kept for compatibility purpose.
-	ErrRequiredNested2StringRequiredValidation = ErrRequiredOtherNestedStructNested2StringRequiredValidation
 
 	// ErrRequiredOtherNestedStructNested2StringRequiredValidation is returned when the Nested2String is required but not provided.
 	ErrRequiredOtherNestedStructNested2StringRequiredValidation = govaliderrors.ValidationError{Reason: "field Nested2String is required", Path: "Required.OtherNestedStruct.Nested2String", Type: "required"}

--- a/internal/validator/rules/alpha.go
+++ b/internal/validator/rules/alpha.go
@@ -46,32 +46,17 @@ func (v *alphaValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when field [@FIELD] is not alphabetic.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be alphabetic",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sAlphaValidation", v.structName, v.FieldName())
-	currentErrVarName := v.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", v.ErrVariable(),
 		"[@FIELD]", v.FieldName(),
 		"[@PATH]", v.FieldPath().String(),
 		"[@TYPE]", v.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/cel.go
+++ b/internal/validator/rules/cel.go
@@ -64,33 +64,18 @@ func (c *celValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the CEL expression evaluation fails.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] failed CEL validation: [@EXPRESSION]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sCELValidation", c.structName, c.FieldName())
-	currentErrVarName := c.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", c.ErrVariable(),
 		"[@FIELD]", c.FieldName(),
 		"[@PATH]", c.FieldPath().String(),
 		"[@EXPRESSION]", c.expression,
 		"[@TYPE]", c.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/email.go
+++ b/internal/validator/rules/email.go
@@ -48,32 +48,17 @@ func (e *emailValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the field is not a valid email address.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be a valid email address",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sEmailValidation", e.structName, e.FieldName())
-	currentErrVarName := e.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", e.ErrVariable(),
 		"[@FIELD]", e.FieldName(),
 		"[@PATH]", e.FieldPath().String(),
 		"[@TYPE]", e.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/enum.go
+++ b/internal/validator/rules/enum.go
@@ -67,33 +67,18 @@ func (e *enumValidator) Err() string {
 
 	enumList := strings.Join(e.enumValues, ", ")
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the value is not in the allowed enum values [@ENUM_LIST].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be one of [@ENUM_LIST]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sEnumValidation", e.structName, e.FieldName())
-	currentErrVarName := e.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", e.ErrVariable(),
 		"[@FIELD]", e.FieldName(),
 		"[@PATH]", e.FieldPath().String(),
 		"[@ENUM_LIST]", enumList,
 		"[@TYPE]", e.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/gt.go
+++ b/internal/validator/rules/gt.go
@@ -48,33 +48,18 @@ func (m *gtValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the value of the field is less than the [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be greater than [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sGTValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.gtValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/gte.go
+++ b/internal/validator/rules/gte.go
@@ -48,33 +48,18 @@ func (m *gteValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the value of the field is less than [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be greater than or equal to [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sGTEValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.gteValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/ipv4.go
+++ b/internal/validator/rules/ipv4.go
@@ -48,32 +48,17 @@ func (v *ipv4Validator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-  `
-
 	const errTemplate = `
 	  // [@ERRVARIABLE] is returned when the [@FIELD] fails ipv4 validation.
 	  [@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] failed ipv4 validation",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sIpv4Validation", v.structName, v.FieldName())
-	currentErrVarName := v.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", v.ErrVariable(),
 		"[@FIELD]", v.FieldName(),
 		"[@PATH]", v.FieldPath().String(),
 		"[@TYPE]", v.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/ipv6.go
+++ b/internal/validator/rules/ipv6.go
@@ -48,32 +48,17 @@ func (v *ipv6Validator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-  `
-
 	const errTemplate = `
 	  // [@ERRVARIABLE] is returned when the [@FIELD] fails ipv6 validation.
 	  [@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] failed ipv6 validation",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sIpv6Validation", v.structName, v.FieldName())
-	currentErrVarName := v.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", v.ErrVariable(),
 		"[@FIELD]", v.FieldName(),
 		"[@PATH]", v.FieldPath().String(),
 		"[@TYPE]", v.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/length.go
+++ b/internal/validator/rules/length.go
@@ -47,33 +47,18 @@ func (l *lengthValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the length of the field is not exactly [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] length must be exactly [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sLengthValidation", l.structName, l.FieldName())
-	currentErrVarName := l.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", l.ErrVariable(),
 		"[@FIELD]", l.FieldName(),
 		"[@PATH]", l.FieldPath().String(),
 		"[@VALUE]", l.lengthValue,
 		"[@TYPE]", l.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/lt.go
+++ b/internal/validator/rules/lt.go
@@ -48,33 +48,18 @@ func (m *ltValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the value of the field is greater than the [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be less than [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sLTValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.ltValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/lte.go
+++ b/internal/validator/rules/lte.go
@@ -48,33 +48,18 @@ func (m *lteValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the value of the field is greater than [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be less than or equal to [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sLTEValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.lteValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/maxitems.go
+++ b/internal/validator/rules/maxitems.go
@@ -48,33 +48,18 @@ func (m *maxItemsValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the length of the field exceeds the maximum of [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must have a maximum of [@VALUE] items",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sMaxItemsValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.maxItemsValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/maxlength.go
+++ b/internal/validator/rules/maxlength.go
@@ -48,33 +48,18 @@ func (m *maxLengthValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the length of the field exceeds the maximum of [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must have a maximum length of [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sMaxLengthValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.maxLengthValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/minitems.go
+++ b/internal/validator/rules/minitems.go
@@ -48,33 +48,18 @@ func (m *minItemsValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the length of the field is less than the minimum of [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must have a minimum of [@VALUE] items",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sMinItemsValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.minItemsValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/minlength.go
+++ b/internal/validator/rules/minlength.go
@@ -48,33 +48,18 @@ func (m *minLengthValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the length of the field is less than the minimum of [@VALUE].
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must have a minimum length of [@VALUE]",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sMinLengthValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@VALUE]", m.minLengthValue,
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/numeric.go
+++ b/internal/validator/rules/numeric.go
@@ -45,32 +45,17 @@ func (m *numericValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the field [@FIELD] is not numeric.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be numeric",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sNumericValidation", m.structName, m.FieldName())
-	currentErrVarName := m.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", m.ErrVariable(),
 		"[@FIELD]", m.FieldName(),
 		"[@PATH]", m.FieldPath().String(),
 		"[@TYPE]", m.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/required.go
+++ b/internal/validator/rules/required.go
@@ -66,32 +66,17 @@ func (r *requiredValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is returned when the [@FIELD] is required but not provided.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] is required",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sRequiredValidation", r.structName, r.FieldName())
-	currentErrVarName := r.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", r.ErrVariable(),
 		"[@FIELD]", r.FieldName(),
 		"[@PATH]", r.FieldPath().String(),
 		"[@TYPE]", r.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/url.go
+++ b/internal/validator/rules/url.go
@@ -47,32 +47,17 @@ func (u *urlValidator) Err() string {
 
 	validator.GeneratorMemory[key] = true
 
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
-
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the field is not a valid URL.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be a valid URL",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sURLValidation", u.structName, u.FieldName())
-	currentErrVarName := u.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", u.ErrVariable(),
 		"[@FIELD]", u.FieldName(),
 		"[@PATH]", u.FieldPath().String(),
 		"[@TYPE]", u.ruleName,
 	)
-
-	if currentErrVarName != legacyErrVarName {
-		return replacer.Replace(deprecationNoticeTemplate + errTemplate)
-	}
 
 	return replacer.Replace(errTemplate)
 }

--- a/internal/validator/rules/uuid.go
+++ b/internal/validator/rules/uuid.go
@@ -40,45 +40,26 @@ func (u *uuidValidator) FieldPath() validator.FieldPath {
 }
 
 func (u *uuidValidator) Err() string {
-	var result strings.Builder
-
 	key := fmt.Sprintf(uuidKey, u.structName+u.FieldPath().CleanedPath())
 	if validator.GeneratorMemory[key] {
-		return result.String()
+		return ""
 	}
 
 	validator.GeneratorMemory[key] = true
-
-	const deprecationNoticeTemplate = `
-		// Deprecated: Use [@ERRVARIABLE]
-		//
-		// [@LEGACYERRVAR] is deprecated and is kept for compatibility purpose.
-		[@LEGACYERRVAR] = [@ERRVARIABLE]
-	`
 
 	const errTemplate = `
 		// [@ERRVARIABLE] is the error returned when the field is not a valid UUID.
 		[@ERRVARIABLE] = govaliderrors.ValidationError{Reason:"field [@FIELD] must be a valid UUID",Path:"[@PATH]",Type:"[@TYPE]"}
 	`
 
-	legacyErrVarName := fmt.Sprintf("Err%s%sUUIDValidation", u.structName, u.FieldName())
-	currentErrVarName := u.ErrVariable()
-
 	replacer := strings.NewReplacer(
-		"[@ERRVARIABLE]", currentErrVarName,
-		"[@LEGACYERRVAR]", legacyErrVarName,
+		"[@ERRVARIABLE]", u.ErrVariable(),
 		"[@FIELD]", u.FieldName(),
 		"[@PATH]", u.FieldPath().String(),
 		"[@TYPE]", u.ruleName,
 	)
 
-	if currentErrVarName != legacyErrVarName {
-		result.WriteString(replacer.Replace(deprecationNoticeTemplate + errTemplate))
-	} else {
-		result.WriteString(replacer.Replace(errTemplate))
-	}
-
-	return result.String()
+	return replacer.Replace(errTemplate)
 }
 
 func (u *uuidValidator) ErrVariable() string {


### PR DESCRIPTION
## Summary

- Remove `deprecationNoticeTemplate` and legacy error variable generation from all 19 validator rules and the scaffold template
- Generated validation code no longer emits backward-compatible aliases (e.g., `ErrStructFieldTypeValidation`) for the old naming convention
- Only the current `FieldPath`-based error variable names (e.g., `ErrCleanedPathTypeValidation`) are generated
- Update golden test files to reflect the simplified generated output

## Breaking Change

Users relying on the deprecated legacy error variable names (e.g., `ErrUserNameRequiredValidation` as an alias) will need to migrate to the current naming convention. The deprecated aliases were marked as `// Deprecated` in previous versions.

## Test plan

- [x] All golden tests updated and passing
- [x] All unit tests passing (`go test ./...`)
- [x] Test module tests passing (`cd test && go test ./...`)
- [x] `go vet` passes
- [x] Generated test code verified to not contain deprecated aliases