### PR TITLE
refactor: change old marker format from warning to error diagnostic

### DIFF
--- a/internal/analyzers/markers/analyzer.go
+++ b/internal/analyzers/markers/analyzer.go
@@ -1,9 +1,8 @@
 package markers
 
 import (
-	"fmt"
 	"go/ast"
-	"os"
+	"go/token"
 	"reflect"
 	"strings"
 
@@ -99,8 +98,7 @@ func collectTypeMarkers(pass *analysis.Pass, genDecl *ast.GenDecl, results *mark
 	}
 
 	for _, doc := range genDecl.Doc.List {
-		pos := pass.Fset.Position(doc.Pos())
-		markerContent, ok := parseMarkerComment(doc.Text, pos.Filename, pos.Line)
+		markerContent, ok := parseMarkerComment(pass, doc.Text, doc.Pos())
 
 		if !ok {
 			continue
@@ -152,8 +150,7 @@ func fieldMarkers(pass *analysis.Pass, field *ast.Field, results *markers) {
 	}
 
 	for _, doc := range field.Doc.List {
-		pos := pass.Fset.Position(doc.Pos())
-		markerContent, ok := parseMarkerComment(doc.Text, pos.Filename, pos.Line)
+		markerContent, ok := parseMarkerComment(pass, doc.Text, doc.Pos())
 
 		if !ok {
 			continue
@@ -177,17 +174,18 @@ func fieldMarkers(pass *analysis.Pass, field *ast.Field, results *markers) {
 
 // parseMarkerComment parses a comment and extracts the marker content.
 // It supports both old format "// +govalid:" and new format "//govalid:".
+// Old format reports a diagnostic error and is skipped.
 // Returns the marker content (e.g., "govalid:required") and true if valid, or empty string and false if not a marker.
-func parseMarkerComment(text, filename string, line int) (string, bool) {
+func parseMarkerComment(pass *analysis.Pass, text string, pos token.Pos) (string, bool) {
 	// New format: //govalid:xxx (recommended, go doc directive style)
 	if strings.HasPrefix(text, "//govalid:") {
 		return strings.TrimPrefix(text, "//"), true
 	}
-	// Old format: // +govalid:xxx (deprecated, kept for backward compatibility)
+	// Old format: // +govalid:xxx (deprecated, report error and skip)
 	if strings.HasPrefix(text, "// +govalid:") {
-		fmt.Fprintf(os.Stderr, "\033[33mWARNING\033[0m: %s:%d: "+`deprecated marker format "// +govalid:"; use "//govalid:" instead (run 'govalid migrate' to fix)`+"\n", filename, line)
+		pass.Reportf(pos, `deprecated marker format "// +govalid:"; use "//govalid:" instead (run 'govalid migrate' to fix)`)
 
-		return strings.TrimPrefix(text, "// +"), true
+		return "", false
 	}
 
 	return "", false

--- a/internal/analyzers/markers/testdata/src/b/b.go
+++ b/internal/analyzers/markers/testdata/src/b/b.go
@@ -1,26 +1,26 @@
 package b
 
-// Test backward compatibility with old format (// +govalid:)
+// Test that old format (// +govalid:) reports an error diagnostic and is skipped.
 
 type OldFormatMarkers struct {
-	// +govalid:required
-	Required string // want Required:`Identifier: "govalid:required", Expressions: {no expressions}`
+	// +govalid:required // want `deprecated marker format`
+	Required string
 
-	// +govalid:lt=10
-	Min int // want Min:`Identifier: "govalid:lt", Expressions: {govalid:lt: 10}`
+	// +govalid:lt=10 // want `deprecated marker format`
+	Min int
 
-	// +govalid:required
-	// +govalid:lt=10
-	RequiredAndMin string // want RequiredAndMin:`Identifier: "govalid:required", Expressions: {no expressions}` // want RequiredAndMin:`Identifier: "govalid:lt", Expressions: {govalid:lt: 10}`
+	// +govalid:required // want `deprecated marker format`
+	// +govalid:lt=10 // want `deprecated marker format`
+	RequiredAndMin string
 }
 
-// +govalid:required
-type TypeLevelOldFormat struct { // want TypeLevelOldFormat:`Identifier: "govalid:required", Expressions: {no expressions}`
+// +govalid:required // want `deprecated marker format`
+type TypeLevelOldFormat struct {
 	String string
 
-	// +govalid:required
-	RequiredString int // want RequiredString:`Identifier: "govalid:required", Expressions: {no expressions}`
+	// +govalid:required // want `deprecated marker format`
+	RequiredString int
 
-	// +govalid:email
-	Email string // want Email:`Identifier: "govalid:email", Expressions: {no expressions}`
+	// +govalid:email // want `deprecated marker format`
+	Email string
 }


### PR DESCRIPTION
## Summary

- Change deprecated `// +govalid:` marker format from stderr WARNING to `pass.Reportf` error diagnostic
- Old format markers are now reported as errors and **skipped** (no longer processed)
- Error message directs users to use `//govalid:` format or run `govalid migrate`
- Remove `fmt` and `os` imports that were only used for the stderr warning

## Changes

- `internal/analyzers/markers/analyzer.go`: Update `parseMarkerComment` to use `pass.Reportf` and return `"", false` for old format
- `internal/analyzers/markers/testdata/src/b/b.go`: Update test expectations from fact assertions to diagnostic assertions

## Test plan

- [x] `TestOldFormat` verifies diagnostic is reported for each old format marker
- [x] `Test` (new format) continues to work unchanged
- [x] All tests pass with `go test ./... -shuffle on -race`