### PR TITLE
ci: fix pinact-check install failure

### DIFF
--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -19,11 +19,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install pinact
-        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          repo: suzuki-shunsuke/pinact
-          tag: v3.9.0
+          go-version-file: go.mod
+
+      - name: Install pinact
+        run: go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0
 
       - name: Run pinact check
         run: pinact run --check


### PR DESCRIPTION
## Description

The `pinact-check` workflow has been failing at the **Install pinact** step. `jaxxstorm/action-install-gh-release` cannot install pinact `v3.9.0` because that release archive now ships additional files (`LICENSE`, `CODEOWNERS`, `third_party_licenses/...`). The installer treats each file as the binary and copies them into a PATH directory, failing with `EACCES: permission denied` on the license files.

`pinact run --check` itself passes locally — all actions are already pinned. Only the installation was broken.

This replaces the release-archive installer with `go install`, which is robust for this Go repository and avoids the installer's multi-file handling entirely. `setup-go` is pinned to a commit SHA (consistent with the other workflows); the `go install ...@v3.9.0` line is a module version reference and is not in scope for pinact's action pinning.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0` succeeds locally
- [x] `pinact run --check` exits 0 against this branch (including the modified workflow)
- [ ] `pinact-check` passes on this PR