### PR TITLE
ci: switch read-only checks from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/fmt-check.yaml
+++ b/.github/workflows/fmt-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/go-mod-check.yaml
+++ b/.github/workflows/go-mod-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/go-vulncheck.yaml
+++ b/.github/workflows/go-vulncheck.yaml
@@ -1,7 +1,7 @@
 name: Vulnerability Check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches: [ main ]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/test-code-generation-check.yaml
+++ b/.github/workflows/test-code-generation-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Description

Follow-up to #264. Switches the read-only CI checks from `pull_request_target` to `pull_request`:

- fmt-check, go-mod-check, go-vulncheck, lint, pinact-check, release-check, test-code-generation-check, unit-test

These checks only lint/format/vet/build/test/scan the code and check out the PR head. Running them under `pull_request_target` grants base-branch secrets and an elevated token to untrusted PR code, which is unnecessary and unsafe. `pull_request` runs them without secrets, which is the correct trigger for read-only checks. The `push` / `schedule` triggers on these workflows are unchanged.

`fuzz-on-pr` is intentionally **kept** on `pull_request_target` because it has `pull-requests: write` / `issues: write` and posts fuzz results back to the PR.

## Type of Change

- [x] Refactoring / CI hardening (no functional changes to the build)

## Notes

- **Merge after #264.** This branch only changes trigger keywords; #264 changes the pinact install step (different lines, no conflict). Until #264 is merged into main, `pinact-check` on this PR runs main's old (broken) installer and will be red for that reason alone.

## Test plan

- [x] Only the `on:` trigger keyword changed in 8 workflows; `fuzz-on-pr` left as `pull_request_target`
- [ ] After #264 merges, all checks on this PR pass