### PR TITLE
ci: add go.mod toolchain directive so pinact can be installed

### DIFF
--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -22,12 +22,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          # Use the latest stable Go: pinact requires a newer Go than the
-          # version pinned in go.mod, and setup-go would otherwise pin
-          # GOTOOLCHAIN=local and block the toolchain upgrade.
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Install pinact
+        # pinact requires a newer Go than the version pinned in go.mod. setup-go
+        # pins GOTOOLCHAIN=local, so override it to let Go download and use the
+        # toolchain that pinact requires.
+        env:
+          GOTOOLCHAIN: auto
         run: go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0
 
       - name: Run pinact check

--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -25,11 +25,6 @@ jobs:
           go-version-file: go.mod
 
       - name: Install pinact
-        # pinact requires a newer Go than the version pinned in go.mod. setup-go
-        # pins GOTOOLCHAIN=local, so override it to let Go download and use the
-        # toolchain that pinact requires.
-        env:
-          GOTOOLCHAIN: auto
         run: go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0
 
       - name: Run pinact check

--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -22,7 +22,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          # Use the latest stable Go: pinact requires a newer Go than the
+          # version pinned in go.mod, and setup-go would otherwise pin
+          # GOTOOLCHAIN=local and block the toolchain upgrade.
+          go-version: stable
 
       - name: Install pinact
         run: go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sivchari/govalid
 
 go 1.25.0
 
+toolchain go1.25.6
+
 require (
 	github.com/google/cel-go v0.27.0
 	github.com/gostaticanalysis/codegen v0.1.0


### PR DESCRIPTION
## Description

Follow-up to #264. The `go install` of pinact `v3.9.0` fails in `pinact-check`:

```
github.com/suzuki-shunsuke/pinact/v3@v3.9.0 requires go >= 1.25.6 (running go 1.25.0; GOTOOLCHAIN=local)
```

go.mod pins `go 1.25.0`, so `setup-go` installs 1.25.0 and pins `GOTOOLCHAIN=local`, and `go install pinact` cannot build.

Fix by adding a `toolchain go1.25.6` directive to go.mod. `setup-go` (v6) reads the `toolchain` directive and installs that toolchain, so `go install pinact` works with no `GOTOOLCHAIN` override. The `go 1.25.0` language-version directive is unchanged, so the minimum supported Go is not raised.

Now that `pinact-check` runs on `pull_request` (#265), this fix is validated by this PR's own `pinact-check`, which passes (along with `go-mod-check`).

## Type of Change

- [x] Bug fix (CI)

## Test plan

- [x] `go build ./...` and `go mod tidy` produce no diff with the toolchain directive
- [x] `pinact-check` passes on this PR
- [x] `go-mod-check` passes (toolchain directive is stable under `go mod tidy`)